### PR TITLE
Fixed Crashing With No IP

### DIFF
--- a/DataHelper.cs
+++ b/DataHelper.cs
@@ -183,13 +183,21 @@ namespace LogiWiz
         public static bool TestConnection(string endpoint)
         {
             bool ConnectionGood = true;
-            Ping netTest = new Ping();
-            PingReply pingRes = netTest.Send(endpoint, 1000);
-            if (pingRes.Status.ToString() == "TimedOut")
+            try
+            {
+                Ping netTest = new Ping();
+                PingReply pingRes = netTest.Send(endpoint, 1000);
+                if (pingRes.Status.ToString() == "TimedOut")
+                {
+                    ConnectionGood = false;
+                }
+                return ConnectionGood;
+            }
+            catch
             {
                 ConnectionGood = false;
+                return ConnectionGood;
             }
-            return ConnectionGood;
         }
 
         private static string SendData(string reqParams, string CurrIP)


### PR DESCRIPTION
Fixed #4 issue with try/catch block in the "TestConnection" function. Will now just return false if attempting to change a bulb's state when no bulb is selected.